### PR TITLE
Improve MultiprocessIterator

### DIFF
--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -255,13 +255,13 @@ class _PrefetchLoop(object):
             if indices is None:  # stop iteration
                 batch = None
             elif pool is None:  # measure mode
-                batch = list(self.dataset[idx] for idx in indices)
+                batch = [self.dataset[idx] for idx in indices]
                 self.mem_size = max(map(_measure, batch))
                 self._allocate_shared_memory()
             else:
                 data_it = pool.imap(
                     _fetch_run, enumerate(indices), chunk_size)
-                batch = list(_unpack(data, self.mem_bulk) for data in data_it)
+                batch = [_unpack(data, self.mem_bulk) for data in data_it]
 
             self.comm.put(batch, self.prefetch_state, reset_count)
             return True

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -97,11 +97,11 @@ class MultiprocessIterator(iterator.Iterator):
             self.dataset, self.batch_size, self.repeat, self.shuffle,
             self.n_processes, self.n_prefetch, self.shared_mem)
 
-        comm = self._comm
-        del self._comm
-        other.__dict__.update(self.__dict__)
-        self._comm = comm
-        other.__class__ = self.__class__
+        other.current_position = self.current_position
+        other.epoch = self.epoch
+        other.is_new_epoch = self.is_new_epoch
+        other._previous_epoch_detail = self._previous_epoch_detail
+        other._order = self._order
 
         other._set_prefetch_state()
         return other


### PR DESCRIPTION
- Avoid ctrl+C problem
  + https://stackoverflow.com/questions/1408356/keyboard-interrupts-with-pythons-multiprocessing-pool
  + https://stackoverflow.com/questions/11312525/catch-ctrlc-sigint-and-exit-multiprocesses-gracefully-in-python
- Fix `__copy__` to improve readability.
- Use list comprehension instead of `list` function.